### PR TITLE
feat/update-slow-start-option

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ resource "aws_lb_target_group" "this" {
   vpc_id               = var.vpc_id
   target_type          = lookup(each.value, "target_type", "ip")
   deregistration_delay = var.target_group_deregistration_delay
+  slow_start           = var.slow_start
 
   health_check {
     enabled             = lookup(each.value.health_check, "enabled", null)

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,12 @@ variable "custom_header_token" {
   default     = ""
 }
 
+variable "slow_start" {
+  description = "(Optional) Amount time for TargetGroup wait before check the farget-service. The range 30-900 seconds or 0 to disable. Not compatible with the Least outstanding requests and Weighted random routing algorithms. The default value is 0 seconds."
+  type        = number
+  default     = 0  
+}
+
 /* -------------------------------------------------------------------------- */
 /*                                Secret & Env                                */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## Add the option slow_start for support TargetGroup delay to check fargate-service

### Adds

- Resource aws_lb_target_group

  - option slow_start

- Variables slow_start

## Why :pleading_face:

- Add the option slow_start in resource aws_lb_target_group
- Add the variables slow_start

